### PR TITLE
deprecate BERT_PRETRAINED_MODEL_ARCHIVE_LIST from transformers

### DIFF
--- a/oscar/modeling/modeling_bert.py
+++ b/oscar/modeling/modeling_bert.py
@@ -12,7 +12,7 @@ from transformers.models.bert.modeling_bert import (BertEmbeddings,
         BertSelfOutput, BertIntermediate, BertOutput,
         BertPooler, BertPreTrainedModel, BertPredictionHeadTransform,
         BertOnlyMLMHead, BertLMPredictionHead,
-        BERT_PRETRAINED_MODEL_ARCHIVE_LIST, load_tf_weights_in_bert)
+        load_tf_weights_in_bert)
 from transformers import BertConfig
 from .modeling_utils import CaptionPreTrainedModel, ImgPreTrainedModel
 from ..utils.cbs import ConstrainedBeamSearch, select_best_beam_with_constraints
@@ -964,7 +964,6 @@ class BertImgForPreTraining(ImgPreTrainedModel):
 
     """
     config_class = BertConfig
-    pretrained_model_archive_list = BERT_PRETRAINED_MODEL_ARCHIVE_LIST
     load_tf_weights = load_tf_weights_in_bert
     base_model_prefix = "bert"
 

--- a/oscar/modeling/modeling_utils.py
+++ b/oscar/modeling/modeling_utils.py
@@ -8,7 +8,6 @@ import torch
 import torch.nn.functional as F
 
 from transformers.models.bert.modeling_bert import (load_tf_weights_in_bert,
-        BERT_PRETRAINED_MODEL_ARCHIVE_LIST,
         BertPreTrainedModel)
 from transformers import PreTrainedModel, BertConfig
 from transformers.utils import (WEIGHTS_NAME, TF_WEIGHTS_NAME)
@@ -21,7 +20,6 @@ class CaptionPreTrainedModel(BertPreTrainedModel):
     """ Expand base class for image captioning modeling.
     """
     config_class = BertConfig
-    pretrained_model_archive_list = BERT_PRETRAINED_MODEL_ARCHIVE_LIST
     load_tf_weights = load_tf_weights_in_bert
     base_model_prefix = 'bert'
 


### PR DESCRIPTION
I tested the branch locally. It resolved the import error.